### PR TITLE
Corrección Promociones Fechas

### DIFF
--- a/views/perfumes.setdatepromocion.view.php
+++ b/views/perfumes.setdatepromocion.view.php
@@ -61,14 +61,18 @@ var guardarPromocion = function()
 		isValid = false;
 	}
 
+	ff = ff.substring(6,10) + ff.substring(3,5) + ff.substring(0,2);
+	fi = fi.substring(6,10) + fi.substring(3,5) + fi.substring(0,2);
 	if (ff<fi)
 	{
+		//alert(ff.substring(6,10) + ff.substring(3,5) + ff.substring(0,2));
+		//alert(fi);
 		Materialize.toast('La Fecha Fin NO debe ser menor a la Fecha Inicio', 5000) // 4000 is the duration of the toast
 		isValid = false;
 	}
 
 	if (!isNumeric(precio))
-	{
+	{		
 		Materialize.toast('Es necesario agregar un Precio de Promoci&oacute;n', 5000) // 4000 is the duration of the toast
 		isValid = false;
 	}


### PR DESCRIPTION
Se corrigió la parte donde no permitía fecha final = un día x, con mayor
numero de mes de la fecha inicial, y x < al día de la fecha inicial
